### PR TITLE
Add basic support for docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+**/.DS_Store
+**/__pycache__
+**/.venv
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/bin
+**/charts
+**/docker-compose*
+**/compose*
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:otp-24-slim
+FROM elixir:1.15
 WORKDIR /app
 COPY . .
 ENTRYPOINT ["iex", "-S", "mix"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM elixir:otp-24-slim
+WORKDIR /app
+COPY . .
+ENTRYPOINT ["iex", "-S", "mix"]
+EXPOSE 4025

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/evl_simulator](https://hexdocs.pm/evl_simulator).
 
+### Docker
+
+The provided Dockerfile can be used to install and run evl-simulator interactively without requiring Erlang or Elixir to be installed on your system.
+
+```shell
+docker build -t evlsimulator:latest .
+docker run -it -p 4025:4025 evlsimulator:latest
+```
+
 ## Usage
 
 You can use the simulator in one of the two following modes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  evlsimulator:
+    restart: 'no'
+    build: .
+    ports:
+      - "4025:4025"
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
Adds basic support for running evl-simulator interactively in a Docker container. This will make it easier to use on systems without Erlang/Elixir installed.